### PR TITLE
Feature/improvements

### DIFF
--- a/compose-files/secret_store.yml
+++ b/compose-files/secret_store.yml
@@ -1,7 +1,7 @@
 version: '2.1'
 services:
   secret-store:
-    image: oceanprotocol/parity-ethereum:acl_docker
+    image: oceanprotocol/parity-ethereum:master
     entrypoint: /entrypoint.sh
     environment:
       CONFIGURE_ACL: "${CONFIGURE_ACL}"


### PR DESCRIPTION
## Description
Added `--only-secret-store` to only run a Parity Secret Store Cluster, and added `--no-ansi` to disable ansi color output. Also changed the default secret store image to `oceanprotocol/parity-ethereum:master`.

## Is this PR related with an open issue?

Related to Issue #97, #95 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()