### PR TITLE
Warn user if ~/.ocean is owned by root

### DIFF
--- a/start_ocean.sh
+++ b/start_ocean.sh
@@ -12,10 +12,13 @@ COMPOSE_DIR="${DIR}/compose-files"
 export PROJECT_NAME="ocean"
 export FORCEPULL="false"
 
+# Ocean filesystem artifacts
+export OCEAN_HOME="${HOME}/.ocean"
+
 # keeper options
 export KEEPER_OWNER_ROLE_ADDRESS="${KEEPER_OWNER_ROLE_ADDRESS}"
 export KEEPER_DEPLOY_CONTRACTS="false"
-export KEEPER_ARTIFACTS_FOLDER="${HOME}/.ocean/keeper-contracts/artifacts"
+export KEEPER_ARTIFACTS_FOLDER="${OCEAN_HOME}/keeper-contracts/artifacts"
 # Specify which ethereum client to run or connect to: development, kovan, spree or nile
 export KEEPER_NETWORK_NAME="nile"
 export NODE_COMPOSE_FILE="${COMPOSE_DIR}/nodes/nile_node.yml"
@@ -63,6 +66,16 @@ function show_banner {
     echo ""
 }
 
+function check_if_issue_100_fixed {
+    if [ -d "$OCEAN_HOME" ]; then
+        uid=$(ls -nd "$OCEAN_HOME" | awk '{print $3;}')
+        if [ "$uid" = "0" ]; then
+            printf $COLOR_R"WARN: $OCEAN_HOME is owned by root\n"$COLOR_RESET >&2
+        fi
+    fi
+}
+
+check_if_issue_100_fixed
 show_banner
 
 COMPOSE_FILES=""

--- a/start_ocean.sh
+++ b/start_ocean.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# start_ocean.sh
+# Copyright (c) 2019 Ocean Protocol contributors
+# SPDX-License-Identifier: Apache-2.0
 
 set -e
 
@@ -66,16 +69,21 @@ function show_banner {
     echo ""
 }
 
-function check_if_issue_100_fixed {
+function check_if_owned_by_root {
     if [ -d "$OCEAN_HOME" ]; then
         uid=$(ls -nd "$OCEAN_HOME" | awk '{print $3;}')
         if [ "$uid" = "0" ]; then
             printf $COLOR_R"WARN: $OCEAN_HOME is owned by root\n"$COLOR_RESET >&2
+        else
+            uid=$(ls -nd "$KEEPER_ARTIFACTS_FOLDER" | awk '{print $3;}')
+            if [ "$uid" = "0" ]; then
+                printf $COLOR_R"WARN: $KEEPER_ARTIFACTS_FOLDER is owned by root\n"$COLOR_RESET >&2
+            fi
         fi
     fi
 }
 
-check_if_issue_100_fixed
+check_if_owned_by_root
 show_banner
 
 COMPOSE_FILES=""


### PR DESCRIPTION
Reminder that #100 is not yet fixed

## Description

Adds warning to start_ocean.sh if ~/.ocean is owned by root

## Is this PR related with an open issue?

Related to Issue #100 
