### PR TITLE
Do not start secret store for public networks (Nile and Kovan)

### DIFF
--- a/compose-files/nodes/kovan_node.yml
+++ b/compose-files/nodes/kovan_node.yml
@@ -13,7 +13,6 @@ services:
       --jsonrpc-hosts all
       --jsonrpc-apis all
       --unsafe-expose
-      --node-key 0xb3244c104fb56d28d3979f6cd14a8b5cf5b109171d293f4454c97c173a9f9374
     volumes:
       - ../networks/kovan/keys:/home/parity/.local/share/io.parity.ethereum/keys/kovan
     ports:

--- a/compose-files/nodes/nile_node.yml
+++ b/compose-files/nodes/nile_node.yml
@@ -16,7 +16,6 @@ services:
       --jsonrpc-apis all
       --unsafe-expose
       --unlock 0x00bd138abd70e2f00903268f3db08f2d25677c9e
-      --node-key 0xb3244c104fb56d28d3979f6cd14a8b5cf5b109171d293f4454c97c173a9f9374
     volumes:
       - ../networks/nile/config:/home/parity/parity/config
       - keeper-node:/home/parity/.local/share/io.parity.ethereum/

--- a/start_ocean.sh
+++ b/start_ocean.sh
@@ -191,9 +191,11 @@ while :; do
         # connects you to kovan
         --local-kovan-node)
             export NODE_COMPOSE_FILE="${COMPOSE_DIR}/nodes/kovan_node.yml"
+            COMPOSE_FILES="${COMPOSE_FILES/ -f ${COMPOSE_DIR}\/secret_store.yml/}"
             export KEEPER_NETWORK_NAME="kovan"
             export ACL_CONTRACT_ADDRESS="$(get_acl_address ${KEEPER_VERSION})"
             printf $COLOR_Y'Starting with local Kovan node...\n\n'$COLOR_RESET
+            printf $COLOR_Y'Starting without Secret Store...\n\n'$COLOR_RESET
             ;;
         # spins up a new ganache blockchain
         --local-ganache-node)
@@ -208,9 +210,11 @@ while :; do
         # connects you to nile ocean testnet
         --local-nile-node)
             export NODE_COMPOSE_FILE="${COMPOSE_DIR}/nodes/nile_node.yml"
+            COMPOSE_FILES="${COMPOSE_FILES/ -f ${COMPOSE_DIR}\/secret_store.yml/}"
             export KEEPER_NETWORK_NAME="nile"
             export ACL_CONTRACT_ADDRESS="$(get_acl_address ${KEEPER_VERSION})"
             printf $COLOR_Y'Starting with local Nile node...\n\n'$COLOR_RESET
+            printf $COLOR_Y'Starting without Secret Store...\n\n'$COLOR_RESET
             ;;
         # spins up spree local testnet
         --local-spree-node)


### PR DESCRIPTION
## Description

There is not sense in starting the secret store in Nile and Kovan, because the new secret store node cannot join to the existing secret store cluster. In that case https://secret-store.dev-ocean.com should be used.

In addition/related, we should not use the same node key for the public Networks (Nile and Kovan).

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()