### PR TITLE
not specifying network == --local-spree-node

### DIFF
--- a/start_ocean.sh
+++ b/start_ocean.sh
@@ -97,6 +97,11 @@ function check_if_owned_by_root {
     fi
 }
 
+function clean_local_contracts {
+    rm -f ${KEEPER_ARTIFACTS_FOLDER}/ready
+    rm -f ${KEEPER_ARTIFACTS_FOLDER}/*.spree.json
+}
+
 check_if_owned_by_root
 show_banner
 
@@ -110,9 +115,6 @@ COMPOSE_FILES+=" -f ${COMPOSE_DIR}/secret_store.yml"
 
 DOCKER_COMPOSE_EXTRA_OPTS="${DOCKER_COMPOSE_EXTRA_OPTS:-}"
 
-# Because the default network is Spree:
-rm -f ${KEEPER_ARTIFACTS_FOLDER}/ready
-rm -f ${KEEPER_ARTIFACTS_FOLDER}/*.spree.json
 
 while :; do
     case $1 in
@@ -277,6 +279,7 @@ while :; do
             printf $COLOR_Y'Starting Ocean...\n\n'$COLOR_RESET
             configure_secret_store
             [ ! -z ${NODE_COMPOSE_FILE} ] && COMPOSE_FILES+=" -f ${NODE_COMPOSE_FILE}"
+            [ ${KEEPER_DEPLOY_CONTRACTS} = "true" ] && clean_local_contracts
             [ ${FORCEPULL} = "true" ] && docker-compose $DOCKER_COMPOSE_EXTRA_OPTS --project-name=$PROJECT_NAME $COMPOSE_FILES pull
             eval docker-compose $DOCKER_COMPOSE_EXTRA_OPTS --project-name=$PROJECT_NAME $COMPOSE_FILES up --remove-orphans
             break

--- a/start_ocean.sh
+++ b/start_ocean.sh
@@ -100,6 +100,7 @@ function check_if_owned_by_root {
 function clean_local_contracts {
     rm -f ${KEEPER_ARTIFACTS_FOLDER}/ready
     rm -f ${KEEPER_ARTIFACTS_FOLDER}/*.spree.json
+    rm -f ${KEEPER_ARTIFACTS_FOLDER}/*.development.json
 }
 
 check_if_owned_by_root
@@ -222,8 +223,6 @@ while :; do
             export KEEPER_MNEMONIC=''
             export KEEPER_NETWORK_NAME="development"
             export KEEPER_DEPLOY_CONTRACTS="true"
-            rm -f ${KEEPER_ARTIFACTS_FOLDER}/ready
-            rm -f ${KEEPER_ARTIFACTS_FOLDER}/*.development.json
             printf $COLOR_Y'Starting with local Ganache node...\n\n'$COLOR_RESET
             ;;
         # connects you to nile ocean testnet
@@ -245,8 +244,6 @@ while :; do
             export KEEPER_MNEMONIC="taxi music thumb unique chat sand crew more leg another off lamp"
             export KEEPER_NETWORK_NAME="spree"
             export KEEPER_DEPLOY_CONTRACTS="true"
-            rm -f ${KEEPER_ARTIFACTS_FOLDER}/ready
-            rm -f ${KEEPER_ARTIFACTS_FOLDER}/*.spree.json
             printf $COLOR_Y'Starting with local Spree node...\n\n'$COLOR_RESET
             ;;
         #################################################


### PR DESCRIPTION
This is a follow-up to pull request #134. The goal of that pull request was to make it so that _not specifying a network_ would be the same as specifying `--local-spree-node`. Unfortunately, it didn't go far enough. In particular:

- the `COMPOSE_FILES` string didn't include the `keeper_contracts.yml` file by default, but Spree needs that. Nile and Kovan should remove it.
- `KEEPER_MNEMONIC` wasn't set to a non-empty value by default, but Spree needs a non-empty value. Ganache, Nile and Kovan can set it back to an empty value.
- `KEEPER_DEPLOY_CONTRACTS` was "false" by default but Spree needs it to be "true" by default. Nile and Kovan can change it back to "false".
- When running a local Spree network, we need to do:

  ```bash
   rm -f ${KEEPER_ARTIFACTS_FOLDER}/ready
   rm -f ${KEEPER_ARTIFACTS_FOLDER}/*.spree.json
   ```

  so those two things should be done by default as well.

Another way to do this would be to have a network option that requires a value to go with it (nile, ganache, kovan, spree) with the default value being spree, but I'm not a Bash wizard so I just fixed the current approach.