### PR TITLE
Update parity version to v2.3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ networks/secret-store/config/config.toml
 .DS_Store
 **/.DS_Store
 ._*
+
+# Barge logs
+start_ocean.log

--- a/compose-files/nodes/kovan_node.yml
+++ b/compose-files/nodes/kovan_node.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   keeper-node:
-    image: parity/parity:v2.3.2
+    image: ${PARITY_IMAGE}
     command:
       --chain kovan
       --base-path /home/parity/base

--- a/compose-files/nodes/nile_node.yml
+++ b/compose-files/nodes/nile_node.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   keeper-node:
-    image: parity/parity:v2.3.2
+    image: ${PARITY_IMAGE}
     command:
       --config /home/parity/parity/config/config.toml
       --db-path /home/parity/chains

--- a/compose-files/nodes/spree_node.yml
+++ b/compose-files/nodes/spree_node.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   keeper-node:
-    image: parity/parity:v2.3.2
+    image: ${PARITY_IMAGE}
     command:
       --config /home/parity/config/config.toml
       --db-path /home/parity/chains

--- a/compose-files/secret_store.yml
+++ b/compose-files/secret_store.yml
@@ -44,7 +44,7 @@ services:
     command: nginx -g 'daemon off;'
 
   secret-store-signing-node:
-    image: parity/parity:v2.3.2
+    image: ${PARITY_IMAGE}
     command:
       --chain /etc/parity/secretstore/chain_${KEEPER_NETWORK_NAME}.json
       --light

--- a/start_ocean.sh
+++ b/start_ocean.sh
@@ -18,6 +18,8 @@ export BRIZO_VERSION=${BRIZO_VERSION:-v0.3.1}
 export KEEPER_VERSION=${KEEPER_VERSION:-v0.9.0}
 export PLEUSTON_VERSION=${PLEUSTON_VERSION:-v0.3.0}
 
+export PARITY_IMAGE='parity/parity:v2.3.3'
+
 export PROJECT_NAME="ocean"
 export FORCEPULL="false"
 


### PR DESCRIPTION
## Description

Parity image v2.3.2 has been removed from dockerhub (https://hub.docker.com/r/parity/parity/tags). So I have updated to v2.3.3 and also configure it only from one point.

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()