### PR TITLE
Make Elasticsearch the default & MongoDB an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Other `start_ocean.sh` options:
 | `--no-aquarius`            | Start up Ocean without the `aquarius` Building Block.                                        |
 | `--no-brizo`               | Start up Ocean without the `brizo` Building Block.                                           |
 | `--no-secret-store`        | Start up Ocean without the `secret-store` Building Block.                                    |
-| `--elasticsearch`          | Start up Ocean with ElasticSearch as DB engine for Aquarius instead of MongoDB.              |
+| `--mongodb`                | Start up Ocean with MongoDB as DB engine for Aquarius instead of Elasticsearch.              |
 | `--local-ganache-node`     | Runs a local `ganache` node.                                                                 |
 | `--local-spree-node`       | Runs a node of the local `spree` network. This is the default.                               |
 | `--local-duero-node`       | Runs a local parity node and connects the node to the `duero` network.                       |
@@ -114,25 +114,26 @@ By default it will start one container. If Pleuston is running, you can open the
 
 This Building Block can be disabled by setting the `--no-pleuston` flag.
 
-| Hostname   | External Port | Internal Url         | Local Url             | Description                                           |
+| Hostname   | External Port | Internal URL         | Local URL             | Description                                           |
 | ---------- | ------------- | -------------------- | --------------------- | ----------------------------------------------------- |
 | `pleuston` | `3000`        | http://pleuston:3000 | http://localhost:3000 | [Pleuston](https://github.com/oceanprotocol/pleuston) |
 
 ### Aquarius
 
-By default it will start two containers (one for aquarius and one for its database engine). By default Barge will use MongoDB as DB Engine. You can use option `--elasticsearch` to use ElasticSearch instead.
+By default it will start two containers (one for Aquarius and one for its database engine). By default, Barge will use Elasticsearch for its database engine. You can use the `--mongodb` option to use MongoDB instead.
 This Building Block can be disabled by setting the `--no-aquarius` flag.
 
-| Hostname   | External Port | Internal Url         | Local Url             | Description                                           |
-| ---------- | ------------- | -------------------- | --------------------- | ----------------------------------------------------- |
-| `aquarius` | `5000`        | http://aquarius:5000 | http://localhost:5000 | [Aquarius](https://github.com/oceanprotocol/aquarius) |
-| `mongodb`  |               |                      |                       | MongoDB used by Aquarius                              |
+| Hostname        | External Port | Internal URL         | Local URL             | Description                                           |
+| --------------- | ------------- | -------------------- | --------------------- | ----------------------------------------------------- |
+| `aquarius`      | `5000`        | http://aquarius:5000 | http://localhost:5000 | [Aquarius](https://github.com/oceanprotocol/aquarius) |
+| `elasticsearch` |               |                      |                       | The Elasticsearch used by Aquarius                    |
+| `mongodb`       |               |                      |                       | The MongoDB used by Aquarius                          |
 
 ### Brizo
 
 By default it will start one container. This Building Block can be disabled by setting the `--no-brizo` flag.
 
-| Hostname | External Port | Internal Url      | Local Url             | Description                                     |
+| Hostname | External Port | Internal URL      | Local URL             | Description                                     |
 | -------- | ------------- | ----------------- | --------------------- | ----------------------------------------------- |
 | `brizo`  | `8030`        | http://brizo:8030 | http://localhost:8030 | [Brizo](https://github.com/oceanprotocol/brizo) |
 
@@ -141,7 +142,7 @@ By default it will start one container. This Building Block can be disabled by s
 Controlled by the `--local-*-node` config switches will start a container `keeper-node` that uses port `8545` to expose an rpc endpoint to the Ethereum Protocol.
 You can find a detailed explanation of how to use this in the [script options](#script-options) section of this document.
 
-| Hostname      | External Port | Internal Url            | Local Url             | Description          |
+| Hostname      | External Port | Internal URL            | Local URL             | Description          |
 | ------------- | ------------- | ----------------------- | --------------------- | -------------------- |
 | `keeper-node` | `8545`        | http://keeper-node:8545 | http://localhost:8545 | An Ethereum RPC node |
 

--- a/start_ocean.sh
+++ b/start_ocean.sh
@@ -49,10 +49,17 @@ export KEEPER_MNEMONIC="taxi music thumb unique chat sand crew more leg another 
 export CONFIGURE_ACL="true"
 export ACL_CONTRACT_ADDRESS=""
 
-# Default Aquarius parameters
-export DB_MODULE="mongodb"
-export DB_HOSTNAME="mongodb"
-export DB_PORT="27017"
+# Default Aquarius parameters: use Elasticsearch
+export DB_MODULE="elasticsearch"
+export DB_HOSTNAME="elasticsearch"
+export DB_PORT="9200"
+export DB_USERNAME="elastic"
+export DB_PASSWORD="changeme"
+export DB_SSL="false"
+export DB_VERIFY_CERTS="false"
+export DB_CA_CERTS=""
+export DB_CLIENT_KEY=""
+export DB_CLIENT_CERT=""
 
 # Export User UID and GID
 export LOCAL_USER_ID=$(id -u)
@@ -118,7 +125,7 @@ COMPOSE_FILES=""
 COMPOSE_FILES+=" -f ${COMPOSE_DIR}/keeper_contracts.yml"
 COMPOSE_FILES+=" -f ${COMPOSE_DIR}/network_volumes.yml"
 COMPOSE_FILES+=" -f ${COMPOSE_DIR}/pleuston.yml"
-COMPOSE_FILES+=" -f ${COMPOSE_DIR}/aquarius_mongodb.yml"
+COMPOSE_FILES+=" -f ${COMPOSE_DIR}/aquarius_elasticsearch.yml"
 COMPOSE_FILES+=" -f ${COMPOSE_DIR}/brizo.yml"
 COMPOSE_FILES+=" -f ${COMPOSE_DIR}/secret_store.yml"
 
@@ -160,7 +167,7 @@ while :; do
             printf $COLOR_Y'Starting without Brizo...\n\n'$COLOR_RESET
             ;;
         --no-aquarius)
-            COMPOSE_FILES="${COMPOSE_FILES/ -f ${COMPOSE_DIR}\/aquarius_mongodb.yml/}"
+            COMPOSE_FILES="${COMPOSE_FILES/ -f ${COMPOSE_DIR}\/aquarius_elasticsearch.yml/}"
             printf $COLOR_Y'Starting without Aquarius...\n\n'$COLOR_RESET
             ;;
         --no-secret-store)
@@ -179,22 +186,15 @@ while :; do
             printf $COLOR_Y'Starting only Secret Store...\n\n'$COLOR_RESET
             ;;
         #################################################
-        # Elasticsearch
+        # MongoDB
         #################################################
-        --elasticsearch)
-            COMPOSE_FILES+=" -f ${COMPOSE_DIR}/aquarius_elasticsearch.yml"
-            COMPOSE_FILES="${COMPOSE_FILES/ -f ${COMPOSE_DIR}\/aquarius_mongodb.yml/}"
-            export DB_MODULE="elasticsearch"
-            export DB_HOSTNAME="elasticsearch"
-            export DB_PORT="9200"
-            export DB_USERNAME="elastic"
-            export DB_PASSWORD="changeme"
-            export DB_SSL="false"
-            export DB_VERIFY_CERTS="false"
-            export DB_CA_CERTS=""
-            export DB_CLIENT_KEY=""
-            export DB_CLIENT_CERT=""
-            printf $COLOR_Y'Starting with Elasticsearch...\n\n'$COLOR_RESET
+        --mongodb)
+            COMPOSE_FILES+=" -f ${COMPOSE_DIR}/aquarius_mongodb.yml"
+            COMPOSE_FILES="${COMPOSE_FILES/ -f ${COMPOSE_DIR}\/aquarius_elasticsearch.yml/}"
+            export DB_MODULE="mongodb"
+            export DB_HOSTNAME="mongodb"
+            export DB_PORT="27017"
+            printf $COLOR_Y'Starting with MongoDB...\n\n'$COLOR_RESET
             ;;
         #################################################
         # Contract/Storage switches


### PR DESCRIPTION
**Please don't merge this pull request until Elasticsearch is working smoothly with Aquarius _et al_.**

- Before, MongoDB was the default and Elasticsearch was an option (as the database engine for Aquarius). This pull request changes Barge so that Elasticsearch is the default and MongoDB is an option.
- Only `start_ocean.sh` and `README.md` were changed. If something else should be changed, please say so!
- Note that only the first letter in Elasticsearch is capitalized.
- Also changed "Url" to "URL" in some column headings (because [URL](https://en.wikipedia.org/wiki/URL) is an acronym).

Resolves #160 
