### PR TITLE
Added chain volumes for each network. Removed validators accounts.

### DIFF
--- a/compose-files/network_volumes.yml
+++ b/compose-files/network_volumes.yml
@@ -9,5 +9,8 @@ networks:
       - subnet: 172.15.0.1/24
 
 volumes:
-  keeper-node:
+  keeper-node-duero:
+  keeper-node-nile:
+  keeper-node-pacific:
+  keeper-node-kovan:
   secret-store:

--- a/compose-files/nodes/duero_node.yml
+++ b/compose-files/nodes/duero_node.yml
@@ -14,10 +14,8 @@ services:
       --jsonrpc-apis all
     volumes:
       - ../networks/duero/config:/home/parity/parity/config
-      - keeper-node:/home/parity/.local/share/io.parity.ethereum/
       - ../networks/duero/keys:/home/parity/.local/share/io.parity.ethereum/keys
-      - ../networks/duero/authorities/validator0.json:/home/parity/.local/share/io.parity.ethereum/keys/duero/validator.json
-      - ../networks/duero/authorities/validator0.pwd:/home/parity/parity/validator.pwd
+      - keeper-node-duero:/home/parity/.local/share/io.parity.ethereum/
     ports:
       - 8545:8545
     networks:

--- a/compose-files/nodes/kovan_node.yml
+++ b/compose-files/nodes/kovan_node.yml
@@ -15,6 +15,7 @@ services:
       --unsafe-expose
     volumes:
       - ../networks/kovan/keys:/home/parity/.local/share/io.parity.ethereum/keys/kovan
+      - keeper-node-kovan:/home/parity/.local/share/io.parity.ethereum/
     ports:
       - 8545:8545
     networks:

--- a/compose-files/nodes/nile_node.yml
+++ b/compose-files/nodes/nile_node.yml
@@ -13,9 +13,8 @@ services:
       --jsonrpc-apis all
     volumes:
       - ../networks/nile/config:/home/parity/parity/config
-      - keeper-node:/home/parity/.local/share/io.parity.ethereum/
-      - ../networks/nile/authorities/validator0.json:/home/parity/.local/share/io.parity.ethereum/keys/nile/validator.json
-      - ../networks/nile/authorities/validator0.pwd:/home/parity/parity/validator.pwd
+      - ../networks/nile/keys:/home/parity/.local/share/io.parity.ethereum/keys
+      - keeper-node-nile:/home/parity/.local/share/io.parity.ethereum/
     ports:
       - 8545:8545
     networks:

--- a/compose-files/nodes/pacific_node.yml
+++ b/compose-files/nodes/pacific_node.yml
@@ -12,10 +12,9 @@ services:
       --jsonrpc-hosts all
       --jsonrpc-apis all
     volumes:
-      - ../networks/nile/config:/home/parity/parity/config
-      - keeper-node:/home/parity/.local/share/io.parity.ethereum/
-      - ../networks/nile/authorities/validator0.json:/home/parity/.local/share/io.parity.ethereum/keys/nile/validator.json
-      - ../networks/nile/authorities/validator0.pwd:/home/parity/parity/validator.pwd
+      - ../networks/pacific/config:/home/parity/parity/config
+      - ../networks/pacific/keys:/home/parity/.local/share/io.parity.ethereum/keys
+      - keeper-node-pacific:/home/parity/.local/share/io.parity.ethereum/
     ports:
       - 8545:8545
     networks:

--- a/networks/duero/config/config.toml
+++ b/networks/duero/config/config.toml
@@ -14,6 +14,3 @@ apis = ["web3", "eth", "pubsub", "net", "parity", "parity_pubsub", "parity_accou
 [network]
 port = 30303
 discovery = true
-
-[account]
-password = ["/home/parity/parity/validator.pwd"]

--- a/networks/nile/config/config.toml
+++ b/networks/nile/config/config.toml
@@ -14,6 +14,3 @@ apis = ["web3", "eth", "pubsub", "net", "parity", "parity_pubsub", "parity_accou
 [network]
 port = 30303
 discovery = true
-
-[account]
-password = ["/home/parity/parity/validator.pwd"]


### PR DESCRIPTION
Added chain volumes for each network. Removed validators accounts for public networks

## Description

Sharing same volume for data chain for different chains has not a lot of sense (it force to delete manually the old volume to fix, and also avoids keeping local sync data).
Also has an account with the password mounted in public networks has not sense. Users must include their accounts in the `keys` folder.

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()