### PR TITLE
allow some faucet config via env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ By default it will start two containers, one for Faucet server and one for its d
 | ---------- | ------------- | -------------------- | --------------------- | ----------------------------------------------------- |
 | `faucet` | `3001`        | http://faucet:3001 | http://localhost:3001 | [Faucet](https://github.com/oceanprotocol/faucet) |
 
+By default the Faucet allows requests every 24hrs. To disable the timespan check you can pass `FAUCET_TIMESPAN=0` as environment variable before starting the script.
+
 ## Spree Network
 
 If you run the `./start_ocean.sh` script with the `--local-spree-node` option (please see [Keeper Node](#keeper-node) section of this document for more details),

--- a/compose-files/faucet.yml
+++ b/compose-files/faucet.yml
@@ -20,5 +20,6 @@ services:
       - keeper-node
     environment:
       FAUCET_NODE: ${KEEPER_RPC_URL}
+      FAUCET_TIMESPAN: ${FAUCET_TIMESPAN}
       NODE_ENV: 'production'
       MONGO_URL: 'mongodb://mongodb:27017/faucetdbtest'

--- a/start_ocean.sh
+++ b/start_ocean.sh
@@ -63,6 +63,9 @@ export DB_CLIENT_KEY=""
 export DB_CLIENT_CERT=""
 CHECK_ELASTIC_VM_COUNT=true
 
+# Default Faucet options
+export FAUCET_TIMESPAN=${FAUCET_TIMESPAN:-24}
+
 # Export User UID and GID
 export LOCAL_USER_ID=$(id -u)
 export LOCAL_GROUP_ID=$(id -g)


### PR DESCRIPTION
For easier testing, allow disabling the time span check.

- Requires https://github.com/oceanprotocol/faucet/pull/29
- Requirement for https://github.com/oceanprotocol/commons/pull/179