### PR TITLE
run check_max_map_count by default

### DIFF
--- a/start_ocean.sh
+++ b/start_ocean.sh
@@ -331,7 +331,7 @@ while :; do
             break
             ;;
         *)
-            [ ${CHECK_ELASTIC_VM_COUNT} = "true" ] && check_max_map_count
+            check_max_map_count
             printf $COLOR_Y'Starting Ocean...\n\n'$COLOR_RESET
             configure_secret_store
             [ -n "${NODE_COMPOSE_FILE}" ] && COMPOSE_FILES+=" -f ${NODE_COMPOSE_FILE}"


### PR DESCRIPTION
We run Aquarius with ElasticSearch by default. If `vm.max_map_count` is too low, ElasticSearch will crash.