### PR TITLE
Have latest version as an aqua default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The default versions are always a combination of component versions which are co
 
 | Aquarius | Provider | Ganache  | ocean-contracts |
 | -------- | -------- | -------- | --------------- |
-| `v2.2.4` | `v0.4.6` | `latest` |  `V0.5.9`
+| `v2.2.6` | `v0.4.6` | `latest` |  `V0.5.9`
 
 You can override the Docker image tag used for a particular component by setting its associated environment variable before calling `start_ocean.sh`:
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The default versions are always a combination of component versions which are co
 
 | Aquarius | Provider | Ganache  | ocean-contracts |
 | -------- | -------- | -------- | --------------- |
-| `v2.2.6` | `v0.4.6` | `latest` |  `V0.5.9`
+| `v2.2.6` | `v0.4.7` | `latest` |  `V0.5.9`
 
 You can override the Docker image tag used for a particular component by setting its associated environment variable before calling `start_ocean.sh`:
 

--- a/start_ocean.sh
+++ b/start_ocean.sh
@@ -29,7 +29,7 @@ COMPOSE_DIR="${DIR}/compose-files"
 # Default versions of Aquarius, Provider
 
 export AQUARIUS_VERSION=${AQUARIUS_VERSION:-v2.2.6}
-export PROVIDER_VERSION=${PROVIDER_VERSION:-latest}
+export PROVIDER_VERSION=${PROVIDER_VERSION:-v0.4.7}
 export CONTRACTS_VERSION=${CONTRACTS_VERSION:-v0.5.9}
 export PROJECT_NAME="ocean"
 export FORCEPULL="false"

--- a/start_ocean.sh
+++ b/start_ocean.sh
@@ -28,7 +28,7 @@ COMPOSE_DIR="${DIR}/compose-files"
 
 # Default versions of Aquarius, Provider
 
-export AQUARIUS_VERSION=${AQUARIUS_VERSION:-latest}
+export AQUARIUS_VERSION=${AQUARIUS_VERSION:-v2.2.6}
 export PROVIDER_VERSION=${PROVIDER_VERSION:-latest}
 export CONTRACTS_VERSION=${CONTRACTS_VERSION:-v0.5.9}
 export PROJECT_NAME="ocean"

--- a/start_ocean.sh
+++ b/start_ocean.sh
@@ -28,7 +28,7 @@ COMPOSE_DIR="${DIR}/compose-files"
 
 # Default versions of Aquarius, Provider
 
-export AQUARIUS_VERSION=${AQUARIUS_VERSION:-v2.2.4}
+export AQUARIUS_VERSION=${AQUARIUS_VERSION:-latest}
 export PROVIDER_VERSION=${PROVIDER_VERSION:-latest}
 export CONTRACTS_VERSION=${CONTRACTS_VERSION:-v0.5.9}
 export PROJECT_NAME="ocean"


### PR DESCRIPTION
## Description
Aqua was hardcoded to 2.2.4 in barge. Need to have `latest` instead.

## Is this PR related with an open issue?

Related to Issue https://github.com/oceanprotocol/ocean.py/issues/255

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)