### PR TITLE
use production endpoint of C2D

### DIFF
--- a/start_ocean.sh
+++ b/start_ocean.sh
@@ -89,7 +89,7 @@ else
 fi
 
 #export OPERATOR_SERVICE_URL=http://127.0.0.1:8050
-export OPERATOR_SERVICE_URL=https://c2d-dev.operator.oceanprotocol.com/
+export OPERATOR_SERVICE_URL=https://nextv.operator.oceanprotocol.com/
 
 
 # Add aquarius to /etc/hosts


### PR DESCRIPTION
## Description
Barge should point to the production endpoint of C2D, and not the dev one

Dev is usually updated with test versions, which might break compatibility until all components are updated (provider, ocean.js/py, etc)