### PR TITLE
Increase default ganache wallet balance to 1_000_000 ETH

### DIFF
--- a/compose-files/ganache.yml
+++ b/compose-files/ganache.yml
@@ -7,4 +7,4 @@ services:
     networks:
       backend:
         ipv4_address: 172.15.0.3
-    entrypoint: ["node", "/app/ganache-core.docker.cli.js", "--db", "./ganache_cache","--chainId","0x2324","--networkId","0x2324","--gasLimit","10000000000","--gasPrice","1","---hardfork","istanbul","--mnemonic","${GANACHE_MNEMONIC}"]
+    entrypoint: ["node", "/app/ganache-core.docker.cli.js", "--db", "./ganache_cache","--chainId","0x2324","--networkId","0x2324","--gasLimit","10000000000","--gasPrice","1","---hardfork","istanbul","--mnemonic","${GANACHE_MNEMONIC}", "-e", "1000000"]


### PR DESCRIPTION
Fixes #285 

Changes:

* Increase default ganache wallet balance to 1_000_000 ETH


Running barge now shows that default accounts have 1_000_000 ETH.

```console
ganache_1          | Available Accounts
ganache_1          | ==================
ganache_1          | (0) 0xe2DD09d719Da89e5a3D0F2549c7E24566e947260 (1000000 ETH)
ganache_1          | (1) 0xBE5449a6A97aD46c8558A3356267Ee5D2731ab5e (1000000 ETH)
ganache_1          | (2) 0xA78deb2Fa79463945C247991075E2a0e98Ba7A09 (1000000 ETH)
ganache_1          | (3) 0x02354A1F160A3fd7ac8b02ee91F04104440B28E7 (1000000 ETH)
ganache_1          | (4) 0xe17D2A07EFD5b112F4d675ea2d122ddb145d117B (1000000 ETH)
ganache_1          | (5) 0xA32C84D2B44C041F3a56afC07a33f8AC5BF1A071 (1000000 ETH)
ganache_1          | (6) 0xFF3fE9eb218EAe9ae1eF9cC6C4db238B770B65CC (1000000 ETH)
ganache_1          | (7) 0x529043886F21D9bc1AE0feDb751e34265a246e47 (1000000 ETH)
ganache_1          | (8) 0xe08A1dAe983BC701D05E492DB80e0144f8f4b909 (1000000 ETH)
ganache_1          | (9) 0xbcE5A3468386C64507D30136685A99cFD5603135 (1000000 ETH)

```