### PR TITLE
Update graphnode to 0.27.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The default versions are always a combination of component versions which are co
 | Provider            |                    | v1.3.4                            | 172.15.0.4      | 8030 -> 8030  |
 | Provider2           |                    | v1.3.4                            | 172.15.0.7      | 8030 -> 8030  |
 | RBAC Server         |                    | main                              | 172.15.0.8      | 3000 -> 3000  |
-| GraphNode           |                    | graphprotocol/graph-node:v0.26.0   | 172.15.0.15     | 9000 -> 8000 ,9001 -> 8001 , 9020 -> 8020,  9030 -> 8030, 9040 -> 8040  |
+| GraphNode           |                    | graphprotocol/graph-node:v0.27.0   | 172.15.0.15     | 9000 -> 8000 ,9001 -> 8001 , 9020 -> 8020,  9030 -> 8030, 9040 -> 8040  |
 | Graphipfs           |                    | ipfs/go-ipfs:v0.4.23              | 172.15.0.16     | 5001 -> 5001  |
 | Graphpgsql          |                    | postgres                          | 172.15.0.7      | 5432 -> 5432  |
 | Dashboard           |                    | portainer/portainer               | 172.15.0.25     | 9100 -> 9000  |

--- a/compose-files/thegraph.yml
+++ b/compose-files/thegraph.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   graph-node:
-    image: graphprotocol/graph-node:v0.26.0
+    image: graphprotocol/graph-node:v0.27.0
     ports:
       - '9000:8000'
       - '9001:8001'


### PR DESCRIPTION
Deployed on rinkeby2, looks good

[query](https://v4.subgraph2.rinkeby.oceanprotocol.com/subgraphs/name/oceanprotocol/ocean-subgraph/graphql?query=query%7B%0Aorders%7Bid%2C%0A++datatoken%7B%0A++++fixedRateExchanges+%7B%0A++++++id%0A++++%7D%0A++++dispensers+%7B%0A++++++id%0A++++%7D%0A++%7D%0A++consumer+%7B%0A++id%0A%7D+payer+%7B%0A++id%0A%7D+gasUsed+gasPrice%7D%7D) here