### PR TITLE
removing erroneous ENV variable NODE_COMPOSE_FILE from purge script

### DIFF
--- a/start_ocean.sh
+++ b/start_ocean.sh
@@ -266,7 +266,7 @@ while :; do
         #################################################
         --purge)
             printf $COLOR_R'Doing a deep clean ...\n\n'$COLOR_RESET
-            eval docker-compose --project-name=$PROJECT_NAME "$COMPOSE_FILES" -f "${NODE_COMPOSE_FILE}" down
+            eval docker-compose --project-name=$PROJECT_NAME "$COMPOSE_FILES" down
             docker network rm ${PROJECT_NAME}_default || true
             docker network rm ${PROJECT_NAME}_backend || true
             ;;


### PR DESCRIPTION
## Description

This PR removes the ENV variable NODE_COMPOSE_FILE which is never set. Previously this resulted in a malformed docker compose command in the purge script. Running `./.start_ocean.sh -purge` now works as expected.

## Is this PR related with an open issue?

Related to Issue #
#312 
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
 
## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] Documentation
