### PR TITLE
Purge should remove ocean home folder. Artifacts in there can be used…

### DIFF
--- a/start_ocean.sh
+++ b/start_ocean.sh
@@ -269,6 +269,7 @@ while :; do
             eval docker-compose --project-name=$PROJECT_NAME "$COMPOSE_FILES" -f "${NODE_COMPOSE_FILE}" down
             docker network rm ${PROJECT_NAME}_default || true
             docker network rm ${PROJECT_NAME}_backend || true
+	    rm -r ${OCEAN_HOME}
             ;;
         --) # End of all options.
             shift


### PR DESCRIPTION
Contracts can remain cached in barge directories, causing deployment of stale contracts & ABIs.
Use `./start_ocean.sh --purge --with-thegraph` to clear and deploy everything