### PR TITLE
add multichain provider in addition to existing providers

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -5,6 +5,7 @@ docker container stop ocean_subgraph_1
 docker container stop ocean_ipfs_1
 docker container stop ocean_postgres_1
 docker container stop ocean_provider_1
+docker container stop ocean_providermulti_1
 docker container stop ocean_provider2_1
 docker container stop ocean_ocean-contracts_1
 docker container stop ocean_elasticsearch_1
@@ -21,6 +22,7 @@ docker container rm ocean_subgraph_1
 docker container rm ocean_ipfs_1
 docker container rm ocean_postgres_1
 docker container rm ocean_provider_1
+docker container rm ocean_providermulti_1
 docker container rm ocean_provider2_1
 docker container rm ocean_ocean-contracts_1
 docker container rm ocean_elasticsearch_1

--- a/compose-files/provider.yml
+++ b/compose-files/provider.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   provider:
     image: oceanprotocol/provider-py:${PROVIDER_VERSION:-latest}
@@ -8,7 +8,7 @@ services:
       backend:
         ipv4_address: 172.15.0.4
     depends_on:
-    - ocean-contracts
+      - ocean-contracts
     environment:
       ARTIFACTS_PATH: "/ocean-contracts/artifacts"
       ADDRESS_FILE: "/ocean-contracts/artifacts/address.json"
@@ -17,23 +17,25 @@ services:
       PARITY_URL: ${NETWORK_RPC_URL}
       PROVIDER_PRIVATE_KEY: ${PROVIDER_PRIVATE_KEY}
       LOG_LEVEL: ${PROVIDER_LOG_LEVEL}
-      OCEAN_PROVIDER_URL: 'http://0.0.0.0:8030'
+      OCEAN_PROVIDER_URL: "http://0.0.0.0:8030"
       OCEAN_PROVIDER_WORKERS: ${PROVIDER_WORKERS}
       IPFS_GATEWAY: ${PROVIDER_IPFS_GATEWAY}
-      OCEAN_PROVIDER_TIMEOUT: '9000'
+      OCEAN_PROVIDER_TIMEOUT: "9000"
       OPERATOR_SERVICE_URL: ${OPERATOR_SERVICE_URL}
       AQUARIUS_URL: ${AQUARIUS_URL:-http://172.15.0.5:5000}
       ARWEAVE_GATEWAY: https://arweave.net/
     volumes:
-    - ${OCEAN_ARTIFACTS_FOLDER}:/ocean-contracts/artifacts/
-    - provider1db:/ocean-provider/db/
+      - ${OCEAN_ARTIFACTS_FOLDER}:/ocean-contracts/artifacts/
+      - provider1db:/ocean-provider/db/
   providermulti:
     image: oceanprotocol/provider-py:multichain
+    ports:
+      - 8032:8030
     networks:
       backend:
         ipv4_address: 172.15.0.104
     depends_on:
-    - ocean-contracts
+      - ocean-contracts
     environment:
       ARTIFACTS_PATH: "/ocean-contracts/artifacts"
       ADDRESS_FILE: "/ocean-contracts/artifacts/address.json"
@@ -42,16 +44,16 @@ services:
       PARITY_URL: ${NETWORK_RPC_URL}
       PROVIDER_PRIVATE_KEY: ${PROVIDER_PRIVATE_KEY}
       LOG_LEVEL: ${PROVIDER_LOG_LEVEL}
-      OCEAN_PROVIDER_URL: 'http://0.0.0.0:8030'
+      OCEAN_PROVIDER_URL: "http://0.0.0.0:8030"
       OCEAN_PROVIDER_WORKERS: ${PROVIDER_WORKERS}
       IPFS_GATEWAY: ${PROVIDER_IPFS_GATEWAY}
-      OCEAN_PROVIDER_TIMEOUT: '9000'
+      OCEAN_PROVIDER_TIMEOUT: "9000"
       OPERATOR_SERVICE_URL: ${OPERATOR_SERVICE_URL}
       AQUARIUS_URL: ${AQUARIUS_URL:-http://172.15.0.5:5000}
       ARWEAVE_GATEWAY: https://arweave.net/
     volumes:
-    - ${OCEAN_ARTIFACTS_FOLDER}:/ocean-contracts/artifacts/
-    - providermultidb:/ocean-provider/db/
+      - ${OCEAN_ARTIFACTS_FOLDER}:/ocean-contracts/artifacts/
+      - providermultidb:/ocean-provider/db/
 volumes:
   provider1db:
   providermultidb:

--- a/compose-files/provider.yml
+++ b/compose-files/provider.yml
@@ -33,7 +33,7 @@ services:
       - 8032:8030
     networks:
       backend:
-        ipv4_address: 172.15.0.104
+        ipv4_address: 172.15.0.9
     depends_on:
       - ocean-contracts
     environment:

--- a/compose-files/provider.yml
+++ b/compose-files/provider.yml
@@ -27,5 +27,33 @@ services:
     volumes:
     - ${OCEAN_ARTIFACTS_FOLDER}:/ocean-contracts/artifacts/
     - provider1db:/ocean-provider/db/
+providermulti:
+    image: oceanprotocol/provider-py:multichain
+    ports:
+      - 8030:8030
+    networks:
+      backend:
+        ipv4_address: 172.15.0.104
+    depends_on:
+    - ocean-contracts
+    environment:
+      ARTIFACTS_PATH: "/ocean-contracts/artifacts"
+      ADDRESS_FILE: "/ocean-contracts/artifacts/address.json"
+      DEPLOY_CONTRACTS: ${DEPLOY_CONTRACTS}
+      NETWORK_URL: ${NETWORK_RPC_URL}
+      PARITY_URL: ${NETWORK_RPC_URL}
+      PROVIDER_PRIVATE_KEY: ${PROVIDER_PRIVATE_KEY}
+      LOG_LEVEL: ${PROVIDER_LOG_LEVEL}
+      OCEAN_PROVIDER_URL: 'http://0.0.0.0:8030'
+      OCEAN_PROVIDER_WORKERS: ${PROVIDER_WORKERS}
+      IPFS_GATEWAY: ${PROVIDER_IPFS_GATEWAY}
+      OCEAN_PROVIDER_TIMEOUT: '9000'
+      OPERATOR_SERVICE_URL: ${OPERATOR_SERVICE_URL}
+      AQUARIUS_URL: ${AQUARIUS_URL:-http://172.15.0.5:5000}
+      ARWEAVE_GATEWAY: https://arweave.net/
+    volumes:
+    - ${OCEAN_ARTIFACTS_FOLDER}:/ocean-contracts/artifacts/
+    - providermultidb:/ocean-provider/db/
 volumes:
   provider1db:
+  providermultidb:

--- a/compose-files/provider.yml
+++ b/compose-files/provider.yml
@@ -29,8 +29,6 @@ services:
     - provider1db:/ocean-provider/db/
   providermulti:
     image: oceanprotocol/provider-py:multichain
-    ports:
-      - 8030:8030
     networks:
       backend:
         ipv4_address: 172.15.0.104

--- a/compose-files/provider.yml
+++ b/compose-files/provider.yml
@@ -27,7 +27,7 @@ services:
     volumes:
     - ${OCEAN_ARTIFACTS_FOLDER}:/ocean-contracts/artifacts/
     - provider1db:/ocean-provider/db/
-providermulti:
+  providermulti:
     image: oceanprotocol/provider-py:multichain
     ports:
       - 8030:8030


### PR DESCRIPTION
In current main, we can run 2 providers.

This PR adds an additional provider (ip: 172.15.0.104), running the multichain version, but sharing the same private key with provider1.

This will help us to test the backwards compatibility by doing a test:
  - publish assets using 172.15.0.4 (provider1) as serviceEndpoint
  - update metadata, and change serviceEndpoint to point to 172.15.0.104 (multichain provider)
  - test consume