### PR TITLE
Speed up Aquarius index time on barge

### DIFF
--- a/compose-files/aquarius.yml
+++ b/compose-files/aquarius.yml
@@ -31,5 +31,6 @@ services:
       EVENTS_ALLOW: "0"
       RUN_EVENTS_MONITOR: "1"
       AQUARIUS_URL: http://172.15.0.5:5000
+      EVENTS_MONITOR_SLEEP_TIME: ${EVENTS_MONITOR_SLEEP_TIME}
     volumes:
     - ${OCEAN_ARTIFACTS_FOLDER}:/ocean-contracts/artifacts/

--- a/start_ocean.sh
+++ b/start_ocean.sh
@@ -87,7 +87,7 @@ cp -r ./certs/* ${OCEAN_CERTS_FOLDER}
 export CONTRACTS_NETWORK_NAME="development"
 
 # Default Aquarius parameters: use Elasticsearch
-export EVENTS_MONITOR_SLEEP_TIME=10
+export EVENTS_MONITOR_SLEEP_TIME=5
 export DB_MODULE="elasticsearch"
 export DB_HOSTNAME="http://172.15.0.6"
 export DB_PORT="9200"

--- a/start_ocean.sh
+++ b/start_ocean.sh
@@ -87,6 +87,7 @@ cp -r ./certs/* ${OCEAN_CERTS_FOLDER}
 export CONTRACTS_NETWORK_NAME="development"
 
 # Default Aquarius parameters: use Elasticsearch
+export EVENTS_MONITOR_SLEEP_TIME=10
 export DB_MODULE="elasticsearch"
 export DB_HOSTNAME="http://172.15.0.6"
 export DB_PORT="9200"


### PR DESCRIPTION
## Description
Change Aquarius's default sleep time from 30 secs to 5 secs

## PRO
It will speed up tests on most components

## CON
We might write poor code, assuming that on a remote network, Aqua will index a new asset fast
